### PR TITLE
Implement and integrate timing_hub module

### DIFF
--- a/src/rtl/timing_hub.v
+++ b/src/rtl/timing_hub.v
@@ -24,7 +24,7 @@ module timing_hub #(
     parameter integer PWM_TICKS = 4096, // ctrl ticks per pwm period
     parameter integer TS_TICKS = 512, // approximate ctrl ticks per sampling period
     parameter integer READ_DCLKS = 24, // bits per ADC sample
-    parameter integer COMPUTE_BUDGET = 416, // ctrl ticks available for pwm compute
+    parameter integer COMPUTE_BUDGET = 399, // ctrl ticks available for pwm compute
     parameter integer SETTLE_TS_MIN = 7, // minimum ADC settling delay
     parameter integer DCLK_RATIO_NOM = 4, // expected ctrl ticks per dclk tick
     parameter integer DCLK_RATIO_TOL = 1, // tolerance for expected ctrl ticks per dclk (\pm TOL)

--- a/src/rtl/timing_hub.v
+++ b/src/rtl/timing_hub.v
@@ -208,7 +208,10 @@ module timing_hub #(
     wire at_wrap = (pwm_ctr == (PWM_TICKS[11:0] - 12'd1));
     wire almost_at_wrap = (pwm_ctr == (PWM_TICKS[11:0] - 12'd2));
     wire early_almost_wrap = pwm_ctr == (PWM_TICKS[11:0] - 12'd3);
-    wire hold_pwm = (realign_active && at_wrap) || arm_pend;
+    
+    // hold only while phase_cnt is strictly less than offset
+    wire phase_hold = arm_pend && (phase_cnt < PWM_PHASE_OFFSET[11:0]);
+    wire hold_pwm = (realign_active && at_wrap) || phase_hold;
     
     // command pulses from FSM
     reg cmd_align_now;

--- a/src/rtl/timing_hub.v
+++ b/src/rtl/timing_hub.v
@@ -1,0 +1,379 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: Marco Blackwell
+// 
+// Create Date: 24.08.2025 21:01:03
+// Design Name: 
+// Module Name: timing_hub
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module timing_hub #(
+    parameter integer PWM_TICKS = 4096, // ctrl ticks per pwm period
+    parameter integer TS_TICKS = 512, // approximate ctrl ticks per sampling period
+    parameter integer DCLK_PER_TS = 128, // dclk ticks per sampling period
+    parameter integer READ_DCLKS = 24, // bits per ADC sample
+    parameter integer COMPUTE_BUDGET = 416, // ctrl ticks available for pwm compute
+    parameter integer SETTLE_TS_MIN = 7, // minimum ADC settling delay
+    parameter integer DCLK_RATIO_NOM = 4, // expected ctrl ticks per dclk tick
+    parameter integer DCLK_RATIO_TOL = 1, // tolerance for expected ctrl ticks per dclk (\pm TOL)
+    parameter integer DCLK_GOOD_COUNT = 256, // consecutive good dclk cycles during DCLKCHK
+    parameter integer PWM_PHASE_OFFSET = 0,
+    parameter integer HB_TIMEOUT_TICKS = 64 // dclk heartbeat timeout in ctrl ticks
+    ) (
+    input wire clk_ctrl,
+    input wire rst_ctrl,
+    input wire dclk,
+    input wire rst_dclk_n,
+    
+    input wire drdy,
+    
+    input wire mmcm1_locked,
+    input wire mmcm2_locked,
+    
+    output reg [11:0]pwm_ctr,
+    output reg pwm_ctr_en,
+    output reg compute_trig,
+    output reg [2:0]drdy_idx,
+    output reg fault,
+    output reg adc_sync_req,
+    output reg [2:0]state
+    );
+    
+    localparam [11:0]DEADLINE_TICKS = PWM_TICKS - COMPUTE_BUDGET - 1;
+    
+    localparam [2:0]
+        ST_RESET = 3'd0,
+        ST_DCLKCHK = 3'd1,
+        ST_DRDYWAIT = 3'd2,
+        ST_RUN = 3'd3,
+        ST_REALIGN = 3'd4,
+        ST_FAULT = 3'd5;
+        
+    // dclk domain block
+    // negative edge dclk sampling of drdy
+    // count 24 dclk negedges to complete a frame read
+    // emit 2 CDC toggles into clk_ctrl: drdy_seen, frame_done
+    wire rst_dclk = ~rst_dclk_n;
+    
+    reg d_in_frame;
+    reg [5:0]dclk_count; // counts 0-23 during sampling
+    reg d_tog_drdy;
+    reg d_tog_frame;
+    
+    // 3-state view in DCLK domain
+    // WAIT_DRDY -> DRDY_HIGH -> SAMPLING -> WAIT...
+    always @(negedge dclk or posedge rst_dclk) begin
+        if (rst_dclk) begin
+            d_in_frame <= 1'b0;
+            dclk_count <= 6'd0;
+            d_tog_drdy <= 1'b0;
+            d_tog_frame <= 1'b0;
+        end else begin            
+            if (!d_in_frame) begin
+                // DRDY_WAIT
+                if (drdy) begin
+                    // DRDY_HIGH
+                    d_tog_drdy <= ~d_tog_drdy;
+                    d_in_frame <= 1'b1;
+                    dclk_count <= 6'd0;
+                end
+            end else begin
+                // SAMPLING
+                dclk_count <= dclk_count + 6'd1;
+                if (dclk_count == (READ_DCLKS - 1)) begin
+                    d_in_frame <= 1'b0;
+                    d_tog_frame <= ~d_tog_frame;
+                end
+            end
+        end
+    end
+    
+    // CDC for DRDY and FRAME_DONE to clk_ctrl
+    (* ASYNC_REG = "TRUE" *) reg [2:0]cdc_drdy_sync;
+    (* ASYNC_REG = "TRUE" *) reg [2:0]cdc_frame_sync;
+    
+    reg drdy_pulse, frame_pulse;
+    always @(posedge clk_ctrl) begin
+        cdc_drdy_sync <= {cdc_drdy_sync[1:0], d_tog_drdy};
+        cdc_frame_sync <= {cdc_frame_sync[1:0], d_tog_frame};
+        
+        drdy_pulse  <= (cdc_drdy_sync[2]  ^ cdc_drdy_sync[1]); // 1-cycle pulse
+        frame_pulse <= (cdc_frame_sync[2] ^ cdc_frame_sync[1]);
+    end
+    
+    // clk_ctrl DCLK stability check
+    // measure clk_ctrl ticks between DCLK edges
+    // many consecutive good measurements settle timer >= 7*T_s (ADC settling time)
+    (* ASYNC_REG = "TRUE" *) reg [2:0]dclk_csync;
+    reg dclk_sync, dclk_sync_q;
+    reg [7:0]good_cnt;
+    reg [7:0]tickspan; // number of ctrl ticks detected for a given dclk period
+    reg [15:0]tick_counter;
+    reg dclk_ok;
+    reg [15:0]settle_counter;
+    
+    reg [7:0]last_cap; // timestamp of last capture
+    reg have_cap; // do we have a last capture to compare against
+    
+    wire settle_done = (settle_counter >= (SETTLE_TS_MIN * TS_TICKS));
+    wire dclk_rise = (dclk_sync & ~dclk_sync_q);
+    
+    always @(posedge clk_ctrl) begin
+        // sync dclk
+        dclk_csync <= {dclk_csync[1:0], dclk};
+        dclk_sync <= dclk_csync[2];
+        dclk_sync_q <= dclk_sync;
+        
+        tick_counter <= tick_counter + 16'd1;
+        
+        if (rst_ctrl) begin
+            good_cnt <= 8'd0;
+            tickspan <= 8'd0;
+            dclk_ok <= 1'b0;
+            settle_counter <= 16'd0;
+            
+            last_cap <= 8'd0;
+            have_cap <= 1'b0;
+        end else begin
+            if (state == ST_DCLKCHK && (mmcm1_locked && mmcm2_locked)) begin  
+                settle_counter <= settle_counter + 16'd1;
+                
+                if (dclk_rise) begin
+                    if (have_cap) begin
+                        tickspan <= (tick_counter[7:0] - last_cap);
+                    end
+                    last_cap <= tick_counter[7:0];
+                    have_cap <= 1'b1;
+                    
+                    if (have_cap && (tickspan >= (DCLK_RATIO_NOM - DCLK_RATIO_TOL)) &&
+                        (tickspan <= (DCLK_RATIO_NOM + DCLK_RATIO_TOL))) begin
+                        if (good_cnt != 8'hFF) good_cnt <= good_cnt + 8'd1;
+                    end else begin
+                        good_cnt <= 8'd0;
+                    end
+                    
+                    if (good_cnt >= DCLK_GOOD_COUNT) dclk_ok <= 1'b1;
+                end
+            end else begin
+                // when not actively checking, keep checker reset
+                good_cnt <= 8'd0;
+                dclk_ok <= 1'b0;
+                settle_counter <= 16'd0;
+                have_cap <= 1'b0;
+            end
+        end
+    end
+    
+    // dclk heartbeat
+    reg [15:0]hb_ctr;
+    wire dclk_edge = (dclk_sync ^ dclk_sync_q); // any edge
+    wire hb_tripped = (hb_ctr >= HB_TIMEOUT_TICKS[15:0]);
+    
+    always @(posedge clk_ctrl) begin
+        if (rst_ctrl) begin
+            hb_ctr <= 16'd0;
+        end else begin
+            if (dclk_edge) hb_ctr <= 16'd0;
+            else if (hb_ctr != 16'hFFFF) hb_ctr <= hb_ctr + 16'd1;
+            
+        end
+    end
+    
+    // pwm timebase for freeze at wrap and phase offset
+    reg realign_mode;
+    reg arm_pend; // hold PWM while applying phase offset
+    reg [11:0]phase_cnt;
+    
+    wire at_wrap = (pwm_ctr == (PWM_TICKS[11:0] - 12'd1));
+    wire hold_pwm = (realign_mode && at_wrap) || arm_pend;
+    
+    always @(posedge clk_ctrl) begin
+        if (rst_ctrl) begin
+            pwm_ctr <= 12'd0;
+            pwm_ctr_en <= 1'b0; // arm after first DRDY
+            arm_pend <= 1'b0;
+            phase_cnt <= 12'd0;
+            realign_mode <= 1'b0;
+        end else begin
+            // default: enable once armed, never disabled after reset
+            if (!pwm_ctr_en && (state != ST_RESET)) begin
+                pwm_ctr_en <= 1'b1;
+            end
+            
+            if (pwm_ctr_en) begin
+                if (hold_pwm);
+                else
+                    pwm_ctr <= at_wrap ? 12'd0 : (pwm_ctr + 12'd1);
+            end
+            
+            if (arm_pend) begin
+                if (phase_cnt == PWM_PHASE_OFFSET[11:0]) begin
+                    arm_pend <= 1'b0;
+                end else begin
+                    phase_cnt <= phase_cnt + 12'd1;
+                end
+            end
+        end
+    end
+    
+    // drdy indexing and compute trigger gating by deadline
+    reg seen_idx7;
+    reg missed_deadline;
+    
+    always @(posedge clk_ctrl) begin
+        if (rst_ctrl) begin
+            drdy_idx <= 3'd0;
+            compute_trig <= 1'b0;
+            seen_idx7 <= 1'b0;
+            missed_deadline <= 1'b0;
+        end else begin
+            compute_trig <= 1'b0; // default low, 1 cycle pulses only
+            
+            if (frame_pulse) begin
+                // gate compute strictly before deadline
+                if (state == ST_RUN && (drdy_idx == 3'd7)) begin
+                    seen_idx7 <= 1'b1;
+                    if (pwm_ctr < DEADLINE_TICKS) begin
+                        compute_trig <= 1'b1;
+                    end else begin
+                        missed_deadline <= 1'b1;
+                    end
+                end
+                
+                drdy_idx <= drdy_idx + 3'd1;
+            end
+            
+            if (at_wrap && !hold_pwm) begin
+                seen_idx7 <= 1'b0;
+                missed_deadline <= 1'b0;
+            end
+            
+            if (state == ST_DRDYWAIT) begin
+                drdy_idx <= 3'd0;
+                seen_idx7 <= 1'b0;
+                missed_deadline <= 1'b0;
+            end
+        end
+    end
+    
+    // finite state machine
+    // maintain pwm as timebase across fault and reset
+    // soft realign freezes at wrap, hard reset doesn't freeze pwm until realign stage
+    
+    reg adc_sync_req_pend; // one shot pulse generator
+    
+    always @(posedge clk_ctrl) begin
+        if (rst_ctrl) begin
+            state <= ST_RESET;
+            fault <= 1'b0;
+            adc_sync_req <= 1'b0;
+            adc_sync_req_pend <= 1'b0;
+            arm_pend <= 1'b0;
+            phase_cnt <= 12'd0;
+            realign_mode <= 1'b0;
+        end else begin
+            // defaults
+            adc_sync_req <= 1'b0;
+            fault <= 1'b0;
+            
+            case (state)
+                ST_RESET: begin
+                    realign_mode <= 1'b0;
+                    arm_pend <= 1'b0;
+                    if (mmcm1_locked && mmcm2_locked) begin
+                        state <= ST_DCLKCHK;
+                    end
+                end
+                
+                ST_DCLKCHK: begin
+                    realign_mode <= 1'b0;
+                    arm_pend <= 1'b0;
+                    if (mmcm1_locked && mmcm2_locked && dclk_ok && settle_done) begin
+                        state <= ST_DRDYWAIT;
+                    end
+                end
+                
+                ST_DRDYWAIT: begin
+                    realign_mode <= 1'b0;
+                    // align PWM start to next DRDY + optional phase offset
+                    if (drdy_pulse) begin
+                        pwm_ctr <= 12'd0;
+                        phase_cnt <= 12'd0;
+                        arm_pend <= (PWM_PHASE_OFFSET != 0);
+                        state <= ST_RUN;
+                    end
+                end
+                
+                ST_RUN: begin
+                    realign_mode <= 1'b0;
+                    
+                    if (hb_tripped || !mmcm1_locked || !mmcm2_locked) begin
+                        fault <= 1'b1;
+                        adc_sync_req <= 1'b1;
+                        adc_sync_req_pend <= 1'b1;
+                        state <= ST_FAULT
+                    end else begin
+                        // period end decisions evald at last tick
+                        if (at_wrap && !hold_pwm) begin
+                            if (!seen_idx7) begin
+                                // no idx 7 this period, hard reset
+                                fault <= 1'b1;
+                                adc_sync_req <= 1'b1;
+                                adc_sync_req_pend <= 1'b1;
+                                state <= ST_FAULT;
+                            end else if (missed_deadline) begin
+                                // saw idx7 but missed deadline, soft reset
+                                realign_mode <= 1'b1;
+                                state <= ST_REALIGN;
+                            end
+                        end
+                    end
+                end
+                
+                ST_REALIGN: begin
+                    // freeze only at wrap, continue at next drdy
+                    fault <= 1'b0;
+                    if (drdy_pulse) begin
+                        realign_mode <= 1'b0;
+                        pwm_ctr <= 12'd0;
+                        phase_cnt <= 12'd0;
+                        arm_pend <= (PWM_PHASE_OFFSET != 0);
+                        state <= ST_RUN;
+                    end
+                end
+                
+                ST_FAULT: begin
+                    // recheck DCLK stability for >= 7*Ts after sync
+                    // return through DCLKCHK, then pause at PWM wrap and wait for DRDY
+                    fault <= 1'b1;
+                    // ensures adc_sync_req is a pulse
+                    if (adc_sync_req_pend) begin
+                        adc_sync_req <= 1'b0;
+                        adc_sync_req_pend <= 1'b0;
+                    end
+                    
+                    if (mmcm1_locked && mmcm2_locked) begin
+                        state <= ST_DCLKCHK;
+                    end
+                end
+                
+                default: state <= ST_RESET;
+                
+            endcase
+        end
+    end
+   
+endmodule

--- a/src/rtl/timing_hub.v
+++ b/src/rtl/timing_hub.v
@@ -35,7 +35,6 @@ module timing_hub #(
     input wire clk_ctrl,
     input wire rst_ctrl,
     input wire dclk,
-    input wire rst_dclk_n,
     
     input wire drdy,
     
@@ -61,11 +60,19 @@ module timing_hub #(
         ST_REALIGN = 3'd4,
         ST_FAULT = 3'd5;
         
+    
+        
     // dclk domain block
     // negative edge dclk sampling of drdy
     // count 24 dclk negedges to complete a frame read
     // emit 2 CDC toggles into clk_ctrl: drdy_seen, frame_done
-    wire rst_dclk = ~rst_dclk_n;
+    
+    (* ASYNC_REG = "true" *) reg [1:0]rst_dclk_sync;
+    always @(negedge dclk or posedge rst_ctrl) begin
+        if (rst_ctrl) rst_dclk_sync <= 2'b11;
+        else rst_dclk_sync <= {1'b0, rst_dclk_sync[1]};
+    end
+    wire rst_dclk = rst_dclk_sync[0]; // active high in dclk domain
     
     reg d_in_frame;
     reg [5:0]dclk_count; // counts 0-23 during sampling

--- a/vivado/esc_mvp/esc_mvp.xpr
+++ b/vivado/esc_mvp/esc_mvp.xpr
@@ -209,7 +209,7 @@
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7z020clg400-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 6 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7z020clg400-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 6 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2024"/>
         <Step Id="init_design"/>
@@ -222,7 +222,6 @@
         <Step Id="post_route_phys_opt_design"/>
         <Step Id="write_bitstream"/>
       </Strategy>
-      <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
       <ReportStrategy Name="Vivado Implementation Default Reports" Flow="Vivado Implementation 2024"/>
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>

--- a/vivado/esc_mvp/esc_mvp.xpr
+++ b/vivado/esc_mvp/esc_mvp.xpr
@@ -112,6 +112,14 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../src/rtl/timing_hub.v">
+        <FileInfo>
+          <Attr Name="AutoDisabled" Val="1"/>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <Config>
         <Option Name="DesignMode" Val="RTL"/>
         <Option Name="TopModule" Val="esc_mvp_top"/>

--- a/vivado/esc_mvp/esc_mvp.xpr
+++ b/vivado/esc_mvp/esc_mvp.xpr
@@ -105,16 +105,15 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
-      <File Path="$PPRDIR/../../src/rtl/esc_mvp_top.sv">
+      <File Path="$PPRDIR/../../src/rtl/timing_hub.v">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
-      <File Path="$PPRDIR/../../src/rtl/timing_hub.v">
+      <File Path="$PPRDIR/../../src/rtl/esc_mvp_top.sv">
         <FileInfo>
-          <Attr Name="AutoDisabled" Val="1"/>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
           <Attr Name="UsedIn" Val="simulation"/>


### PR DESCRIPTION
Introduces the core timing_hub module which is responsible for generating the generating the PWM timebase and synchronising it with the ADC sampling.

- timing_hub contains a state machine to manage clock stability checks, wait for ADC data and run the main PWM counter
- it handles faults like missed compute deadlines, MMCM unlock, and loss of DCLK and generates a compute trigger signal at the correct point in the PWM cycle when the ADC data is ready.

Fault strategy:
To manage synchronisation, a soft and hard reset strategy was used. A soft reset is used for recoverable timing drifts and hard resets are for catastrophic failures where timing integrity is compromised and ADC needs to be restarted.

A soft reset is triggered when the 8th frame_pulse arrives after the computation deadline. When the missed deadline occurs, the state machine sets an internal flag and waits until the next PWM cycle. As the PWM is finishing it's cycle, the need_realign flag triggers a cmd_request_realign which instructs the timebase to freeze the pwm counter at its maximum value. In this state, the system is paused for a few microseconds until the next drdy pulse from the ADC, at which point PWM restarts and the period is now aligned with the ADC's timing.

Hard reset is triggered when no 8th ADC sample is received before the end of the PWM period, indicating severe data stream stall or other fault. Hard reset is also triggered if dclk or mmcm's go dead. This starts an ADC reset, waiting the settling period and checking dclk stability again before resynchronising the PWM period.

Intended during both soft and hard reset is a reuse of old compute up to a max number of cycles (TBD).